### PR TITLE
Increase sleep from 30 to 120 seconds before running build_temp.py

### DIFF
--- a/Docker/source/NeoFuse_multi.sh
+++ b/Docker/source/NeoFuse_multi.sh
@@ -484,12 +484,12 @@ do
 			fi
 		done
 		wait
-		sleep 30 # Extra time to release resources
+		sleep 120 # Extra time to release resources, 120 seconds to make sure all inputs to build_temp.py have been created before proceeding
 		echo " Creating Final Ouptut" | sed "s/^/[`date +"%T"`] /"
 		for j in $PEPLEN; do
 			python3 /usr/local/bin/source/build_temp.py -a $FINALTMP*$j"_ASSOCIATIONS_OUT.txt" -o $FINALTMP$FILE"_"$j > $LOGSDIR$FILE.final.log 2>&1
 			if [ `echo $?` != 0 ]; then
-				echo "An error occured while creating the final output files, check $REALOUT/$FILE/LOGS/$FILE.final.log for more details"
+				echo "An error occured while creating the final output files, check $REALOUT/$FILE/LOGS/$FILE.final.log for more details, error occurred using build_temp.py"
 				exit 1
 			else
 				:
@@ -535,7 +535,7 @@ do
 		for j in $PEPLEN; do
 			python3 /usr/local/bin/source/build_temp_netMHCpan.py -a $FINALTMP*$j"_ASSOCIATIONS_OUT.txt" -o $FINALTMP$FILE"_"$j > $LOGSDIR$FILE.final.log 2>&1
 			if [ `echo $?` != 0 ]; then
-				echo "An error occured while creating the final output files, check $REALOUT/$FILE/LOGS/$FILE.final.log for more details"
+				echo "An error occured while creating the final output files, check $REALOUT/$FILE/LOGS/$FILE.final.log for more details, error occurred using build_temp_netMHCpan.py"
 				exit 1
 			else
 				:

--- a/Docker/source/NeoFuse_single.sh
+++ b/Docker/source/NeoFuse_single.sh
@@ -454,12 +454,12 @@ if [ "$NETMHCPAN" == "false" ]; then
 		fi
 	done
 	wait
-	sleep 30 # Extra time to release resources
+	sleep 120 # Extra time to release resources, 120 seconds to make sure all inputs to build_temp.py have been created before proceeding
 	echo " Creating Final Ouptut" | sed "s/^/[`date +"%T"`] /"
 	for j in $PEPLEN; do
 		python3 /usr/local/bin/source/build_temp.py -a $FINALTMP*$j"_ASSOCIATIONS_OUT.txt" -o $FINALTMP$FILE"_"$j > $LOGSDIR$FILE.final.log 2>&1
 		if [ `echo $?` != 0 ]; then
-			echo "An error occured while creating the final output files, check $REALOUT/$FILE/LOGS/$FILE.final.log for more details"
+			echo "An error occured while creating the final output files, check $REALOUT/$FILE/LOGS/$FILE.final.log for more details, error occurred using build_temp.py"
 			exit 1
 		else
 			:
@@ -506,7 +506,7 @@ else
 	for j in $PEPLEN; do
 		python3 /usr/local/bin/source/build_temp_netMHCpan.py -a $FINALTMP*$j"_ASSOCIATIONS_OUT.txt" -o $FINALTMP$FILE"_"$j > $LOGSDIR$FILE.final.log 2>&1
 		if [ `echo $?` != 0 ]; then
-			echo "An error occured while creating the final output files, check $REALOUT/$FILE/LOGS/$FILE.final.log for more details"
+			echo "An error occured while creating the final output files, check $REALOUT/$FILE/LOGS/$FILE.final.log for more details, error occured using build_temp_netMHCpan.py"
 			exit 1
 		else
 			:


### PR DESCRIPTION
1. Change implemented in both NeoFuse_single.sh and NeoFuse_multi.sh, due to issue mentioned in #11 with NeoFuse_single.sh failing on certain samples. 
2. Error messages creating final outputs changed so that they are specific to the script that failed.

This is just how I changed the scripts myself, there are probably more robust fixes to the issue out there, e.g. the use tests, either in the bash scripts or the build_temp.py to wait if the input files have not yet been created. You might want to implement the fix in a different way.